### PR TITLE
worked on connection.js

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -1,0 +1,21 @@
+const Sequelize = require('sequelize');
+require('dotenv').config();
+
+let sequelize;
+
+if (process.env.JAWSDB_URL) {
+  sequelize = new Sequelize(process.env.JAWSDB_URL);
+} else {
+  sequelize = new Sequelize(
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PASSWORD,
+    {
+      host: 'localhost',
+      dialect: 'mysql',
+      port: 3306
+    }
+  );
+}
+
+module.exports = sequelize;


### PR DESCRIPTION
Creating a database connection via Sequelize on Heroku involves the following steps:
If a JAWSDB_URL is present, it creates a Sequelize instance using that URL. In the absence of a JAWSDB_URL, it creates a Sequelize instance using the .env file.